### PR TITLE
反時計回転を時計回転と同じように修正,pushOutクラスを個別に関数をエクスポートするように変更

### DIFF
--- a/src/js/Clockwise.js
+++ b/src/js/Clockwise.js
@@ -1,5 +1,5 @@
 
-import PushOut from "./PushOut";
+import * as pushOut from "./PushOut";
 import RotateHelper from "./RotateHelper";
 import lodash from "lodash";
 
@@ -21,7 +21,7 @@ export default class Clockwise{
         })
     
         // 補正をかける
-        const corrected =  (new PushOut()).correction(rotated)
+        const corrected =  pushOut.correction(rotated)
     
         // どのブロックにも被って無いならすぐ返す
         if (field.tetriminoIsNotOverlap(corrected)) { return corrected }

--- a/src/js/CounterClockwise.js
+++ b/src/js/CounterClockwise.js
@@ -1,6 +1,7 @@
 
 import PushOut from "./PushOut";
 import RotateHelper from "./RotateHelper";
+import lodash from "lodash";
 
 export default class Clockwise{
     constructor() {
@@ -28,42 +29,54 @@ export default class Clockwise{
         let turnedIn = {}
         if (type == "S" || type == "Z") { 
             // 下に最大2回移動し、それでもだめなら上に最大2回移動する
-            turnedIn = this.turnIn(
-                field, corrected, [this.helper.moveDown, this.helper.moveDown, this.helper.moveUp, this.helper.moveUp]
+            turnedIn = this.helper.turnIn(
+                {
+                    field:field,
+                    coordinate:corrected,
+                    directions:[this.helper.moveDown, this.helper.moveDown]
+                }
             );
         }
         else {
-            // 下､右､下に移動してみて、それでもだめなら上に最大2回移動する
-            turnedIn = this.turnIn(
-                field, corrected, [this.helper.moveDown, this.helper.moveRight,this.helper.moveDown,this.helper.moveUp, this.helper.moveUp]
+            // 下､左､下に移動してみて、それでもだめなら上に最大2回移動する
+
+            // ここで何故かcorrected,古い書き方のrotationに影響がでていた｡
+            turnedIn = this.helper.turnIn(
+                {
+                    field:field,
+                    coordinate:corrected,
+                    directions:[this.helper.moveDown, this.helper.moveRight,this.helper.moveDown]
+                }
             );
         }
     
-        // 回し入れ失敗なら
-        if (turnedIn[0].x == "none") { return Coordinate }
-        return turnedIn
+        // 回し入れ成功ならそれを返す
+        if (turnedIn != null ) { return turnedIn  }
+        
+        // 失敗時したら上げる方法を試す｡
+        // 最初の回転したを入れるのは仕様
+        const liftUpded = this.helper.liftUp({
+            field:field,
+            coordinate:rotated
+        })
+
+        // 押上で問題ないならそれを返す
+        if (liftUpded != null ) { return liftUpded  }
+
+        // ここまでやってだめなら初期値を返す
+        return Coordinate
     }
-    
-    turnIn(field, coordinate, directions) {
-        // directionには関数名が入っていてそのまま関数を使えるらしい｡
-        // jsならではの方法?
-        for (const direction of directions) {
-          const moved = direction(coordinate);
-          if (field.tetriminoIsNotOverlap(moved)) { return moved; }
-        }
-        // すべての方向で移動できなかった場合、失敗フラグを返す
-        return [{ x: "none", y: "none" }];
-      }
     
     /** すべてのブロックを計算して返す */
     calculation({
         coordinate,
         rotationPoint
     }) {
+        const clonedCoordinate = lodash.cloneDeep(coordinate)
         return coordinate.map(
             block => {
             return this.equation({
-                rotationPoint:coordinate[rotationPoint],
+                rotationPoint:clonedCoordinate[rotationPoint],
                 beforeRotation:block
             })
         })

--- a/src/js/CounterClockwise.js
+++ b/src/js/CounterClockwise.js
@@ -1,5 +1,5 @@
 
-import PushOut from "./PushOut";
+import * as pushOut from "./PushOut";
 import RotateHelper from "./RotateHelper";
 import lodash from "lodash";
 
@@ -21,7 +21,7 @@ export default class Clockwise{
         })
     
         // 補正をかける
-        const corrected =  (new PushOut()).correction(rotated)
+        const corrected =  pushOut.correction(rotated)
     
         // どのブロックにも被って無いならすぐ返す
         if (field.tetriminoIsNotOverlap(corrected)) { return corrected }

--- a/src/js/PushOut.js
+++ b/src/js/PushOut.js
@@ -4,34 +4,32 @@ import lodash from "lodash";
  * 主に壁などからブロックを押し出す処理をする
  * 完全に出てくるまで繰り返すためwhile
  */
-
-export default class PushOut {
-    FromTheFloor(coordinate){
+    function FromTheFloor(coordinate){
         let correctedCoordinate = coordinate
 
         // 床から出てくるまで繰り返す
-        while (this.isNeedFloorCorrection(correctedCoordinate)) {
+        while (isNeedFloorCorrection(correctedCoordinate)) {
             correctedCoordinate.forEach(block => { block.y -= 1; });
         }
 
         return correctedCoordinate
     }
 
-    FromTheLeftWall(coordinate){
+    function FromTheLeftWall(coordinate){
         let correctedCoordinate = coordinate
 
         // 左壁から出てくるまで繰り返す
-        while (this.isNeedLeftCorrection(correctedCoordinate)) {
+        while (isNeedLeftCorrection(correctedCoordinate)) {
             correctedCoordinate.forEach(block => { block.x += 1 });
         }
 
         return correctedCoordinate
     }
 
-    FromTheRightWall(coordinate){
+    function FromTheRightWall(coordinate){
         let correctedCoordinate = coordinate
         // 右壁から出てくるまで繰り返す
-        while (this.isNeedRightCorrection(correctedCoordinate)) {
+        while (isNeedRightCorrection(correctedCoordinate)) {
             correctedCoordinate.forEach(block => { block.x -= 1 });
         }
 
@@ -40,43 +38,41 @@ export default class PushOut {
 
     /** 補正が必要かどうか調べる */
     // 一つでも引っかるならfalse
-    isNeedCorrection(coordinate){
-        if (this.isNeedFloorCorrection(coordinate)) {return true}
-        if (this.isNeedLeftCorrection(coordinate) ) {return true}
-        if (this.isNeedRightCorrection(coordinate)) {return true}
+    export function isNeedCorrection(coordinate){
+        if (isNeedFloorCorrection(coordinate)) {return true}
+        if (isNeedLeftCorrection(coordinate) ) {return true}
+        if (isNeedRightCorrection(coordinate)) {return true}
 
         return false
     }
 
     // 左壁を突き抜けてないか
-    isNeedLeftCorrection(coordinate){
+    function isNeedLeftCorrection(coordinate){
         // 1つでも突き抜けてはいけない
         return coordinate.some(block => block.x < 0);
     }
 
     // 右壁を突き抜けてないか
-    isNeedRightCorrection(coordinate){
+    function isNeedRightCorrection(coordinate){
         const rightEdge   = fieldWidth - 1
         // 1つでも突き抜けてはいけない
         return coordinate.some(block => block.x > rightEdge);
     }
 
     // 床を突き抜けてないか
-    isNeedFloorCorrection(coordinate){
+    function isNeedFloorCorrection(coordinate){
         const bottom  = fieldHeight - 1;
         // 1つでも突き抜けてはいけない
         return coordinate.some(block => block.y > bottom);
     }
 
     /** 補正をかける*/
-    correction(coordinate){
+    export function correction(coordinate){
         // 補正をかけた後(色々いじるからクローン)
         const clonedCoordinate = lodash.cloneDeep(coordinate)
-        const coordinatedFloor = this.FromTheFloor(clonedCoordinate)
-        const coordinateLeftwall = this.FromTheLeftWall(coordinatedFloor)
-        const coordinateRightWall = this.FromTheRightWall(coordinateLeftwall)
+        const coordinatedFloor = FromTheFloor(clonedCoordinate)
+        const coordinateLeftwall = FromTheLeftWall(coordinatedFloor)
+        const coordinateRightWall = FromTheRightWall(coordinateLeftwall)
 
         return coordinateRightWall
     }
-
-}

--- a/src/js/RotateHelper.js
+++ b/src/js/RotateHelper.js
@@ -1,4 +1,4 @@
-import PushOut from "./PushOut";
+import * as pushOut from "./PushOut";
 import lodash from "lodash";
 export default class RotateHelper{
     //note: 引数で受け取るのがオブジェクト型だったのでこのような形にする必要があった｡
@@ -7,28 +7,28 @@ export default class RotateHelper{
                 return {x:block.x,y:block.y -= 1 }
             }
         );
-        return (new PushOut()).correction(moved);
+        return pushOut.correction(moved);
     }
 
     moveDown(coordinate){
         const moved = coordinate.map(block => {
             return {x:block.x,y:block.y += 1}
         });
-        return (new PushOut()).correction(moved)
+        return pushOut.correction(moved)
     }
 
     moveLeft(coordinate){
         const moved = coordinate.map(block => {
             return {x:block.x -= 1,y:block.y}
         });
-        return (new PushOut()).correction(moved)
+        return pushOut.correction(moved)
     }
 
     moveRight(coordinate){
         const moved = coordinate.map(block => {
             return {x:block.x += 1,y:block.y}
         });
-        return (new PushOut()).correction(moved)
+        return pushOut.correction(moved)
     }
 
     // 回転入れ


### PR DESCRIPTION
# pushOutクラスを個別に関数をエクスポートするように変更
なぜか
```
constructor(){
  this.pushOut = new PushOut()
}
```
と書くと`pushOut`なんてないと表示されていた｡
※ ログで正しく初期化されているのは確認ずみだし､インポートのパスも間違っていない｡

色々検証､調査しても原因はわからなかった

今までは
(new PushOut).関数名とやっていたが｡いちいちインスタンス化するとパフォーマンス的に良くないらしいので｡
関数をエクスポートする方式に変更した
PushOut.jsにはコンストラクタは無いので特に問題はない